### PR TITLE
fixed LlamaIndex SQL Injection vulnerability

### DIFF
--- a/code/lambdas/action-lambda/README.md
+++ b/code/lambdas/action-lambda/README.md
@@ -16,7 +16,7 @@ Here is the API schema for this lambda:
 #### Prerequisites (requirements.txt)
 
 - boto3==1.34.37
-- llama-index==0.10.6
+- llama-index>=0.12.4
 - llama-index-embeddings-bedrock==0.1.3
 - llama-index-llms-bedrock==0.1.3
 - sqlalchemy==2.0.23

--- a/code/lambdas/action-lambda/requirements.txt
+++ b/code/lambdas/action-lambda/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.34.57
-llama-index==0.10.13
+llama-index>=0.12.4
 llama-index-embeddings-bedrock==0.1.3 
 llama-index-llms-bedrock==0.1.3
 sqlalchemy==2.0.23


### PR DESCRIPTION
*from dependabot*

A vulnerability in the FinanceChatLlamaPack of the run-llama/llama_index repository, versions up to v0.12.3, allows for SQL injection in the run_sql_query function of the database_agent. This vulnerability can be exploited by an attacker to inject arbitrary SQL queries, leading to remote code execution (RCE) through the use of PostgreSQL's large object functionality. The issue is fixed in the stale_packages branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
